### PR TITLE
Add Rounds to each service check run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ runner/runner
 /custom-checks/*
 !/custom-checks/.gitkeep
 !/custom-checks/example.sh
+!/custom-checks/requirements.txt
 
 /submissions/*
 !.gitkeep

--- a/custom-checks/example.sh
+++ b/custom-checks/example.sh
@@ -1,13 +1,14 @@
 #!/bin/sh
 
-# Usage: ./example.sh <address> <team_id> <username> <password>
+# Usage: ./example.sh <round> <address> <team_id> <username> <password>
 
-ADDRESS="$1"
-TEAM_ID="$2"
-USERNAME="$3"
-PASSWORD="$4"
+ROUND="$1"
+ADDRESS="$2"
+TEAM_ID="$3"
+USERNAME="$4"
+PASSWORD="$5"
 
-echo "$ADDRESS" "$TEAM_ID" "$USERNAME" "$PASSWORD"
+echo "$ROUND" "$ADDRESS" "$TEAM_ID" "$USERNAME" "$PASSWORD"
 
 ping -c2 -W2 -w2 "$ADDRESS" && return 0
 

--- a/custom-checks/requirements.txt
+++ b/custom-checks/requirements.txt
@@ -1,0 +1,2 @@
+#Enter your python modules here on newlines: e.g.
+#requests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   db:
     container_name: quotient_database
@@ -49,7 +47,7 @@ services:
       dockerfile: Dockerfile.runner
     deploy:
       mode: replicated
-      replicas: 40 # Adjust based on server resources
+      replicas: 4 # Adjust based on server resources
     restart: always
     privileged: true
     env_file:

--- a/engine/checks/checks.go
+++ b/engine/checks/checks.go
@@ -13,7 +13,7 @@ import (
 
 // checks for each service
 type Runner interface {
-	Run(teamID uint, identifier string, resultsChan chan Result)
+	Run(teamID uint, identifier string, roundID uint, resultsChan chan Result)
 	Runnable() bool
 	Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error
 	GetType() string
@@ -46,6 +46,7 @@ type Result struct {
 	Error       string `json:"error,omitempty"`
 	Points      int    `json:"points,omitempty"`
 	ServiceType string `json:"service_type,omitempty"`
+	RoundID     uint   `json:"round_id"`
 }
 
 func (service *Service) GetType() string {
@@ -131,7 +132,7 @@ func (service *Service) Runnable() bool {
 	return true
 }
 
-func (service *Service) Run(teamID uint, teamIdentifier string, resultsChan chan Result, definition func(teamID uint, teamIdentifier string, checkResult Result, response chan Result)) {
+func (service *Service) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result, definition func(teamID uint, teamIdentifier string, checkResult Result, response chan Result)) {
 	service.Target = strings.Replace(service.Target, "_", teamIdentifier, -1)
 
 	checkResult := Result{
@@ -141,6 +142,7 @@ func (service *Service) Run(teamID uint, teamIdentifier string, resultsChan chan
 		Points:      service.Points,
 		Status:      false,
 		ServiceType: service.ServiceType,
+		RoundID:     roundID,
 	}
 
 	slog.Debug("Running check", "teamID", teamID, "serviceName", service.Name, "target", service.Target)

--- a/engine/checks/custom.go
+++ b/engine/checks/custom.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"al.essio.dev/pkg/shellescape"
@@ -25,7 +26,7 @@ func commandOutput(cmd string) (string, error) {
 	return strings.TrimSpace(string(out)), nil
 }
 
-func (c Custom) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Custom) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 
 		var username, password string
@@ -42,6 +43,7 @@ func (c Custom) Run(teamID uint, teamIdentifier string, resultsChan chan Result)
 
 		// Replace command input keywords
 		formedCommand := c.Command
+		formedCommand = strings.Replace(formedCommand, "ROUND", strconv.FormatUint(uint64(roundID), 10), -1)
 		formedCommand = strings.Replace(formedCommand, "TARGET", c.Target, -1) // is there a case where u need IP and FQDN?
 		formedCommand = strings.Replace(formedCommand, "TEAMIDENTIFIER", teamIdentifier, -1)
 
@@ -84,7 +86,7 @@ func (c Custom) Run(teamID uint, teamIdentifier string, resultsChan chan Result)
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Custom) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/dns.go
+++ b/engine/checks/dns.go
@@ -22,7 +22,7 @@ type DnsRecord struct {
 	Answer []string
 }
 
-func (c Dns) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Dns) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		// Pick a record
 		record := c.Record[rand.Intn(len(c.Record))]
@@ -93,7 +93,7 @@ func (c Dns) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Dns) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/ftp.go
+++ b/engine/checks/ftp.go
@@ -23,7 +23,7 @@ type FtpFile struct {
 	Regex string
 }
 
-func (c Ftp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Ftp) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		conn, err := ftp.Dial(c.Target+":"+strconv.Itoa(c.Port), ftp.DialWithTimeout(time.Duration(c.Timeout)*time.Second))
 		if err != nil {
@@ -108,7 +108,7 @@ func (c Ftp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Ftp) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/imap.go
+++ b/engine/checks/imap.go
@@ -16,7 +16,7 @@ type Imap struct {
 	Encrypted bool
 }
 
-func (c Imap) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Imap) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		// Create a dialer so we can set timeouts
 		dialer := net.Dialer{
@@ -85,7 +85,7 @@ func (c Imap) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Imap) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/ldap.go
+++ b/engine/checks/ldap.go
@@ -14,7 +14,7 @@ type Ldap struct {
 	Encrypted bool
 }
 
-func (c Ldap) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Ldap) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		// Set timeout
 		ldap.DefaultTimeout = time.Duration(c.Timeout) * time.Second
@@ -65,7 +65,7 @@ func (c Ldap) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Ldap) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/ping.go
+++ b/engine/checks/ping.go
@@ -14,7 +14,7 @@ type Ping struct {
 	Percent         int
 }
 
-func (c Ping) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Ping) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		// Create pinger
 		pinger, err := ping.NewPinger(c.Target)
@@ -59,7 +59,7 @@ func (c Ping) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Ping) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/pop3.go
+++ b/engine/checks/pop3.go
@@ -10,7 +10,7 @@ type Pop3 struct {
 	Encrypted bool
 }
 
-func (c Pop3) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Pop3) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		// Create a dialer so we can set timeouts
 		p := pop3.New(pop3.Opt{
@@ -68,7 +68,7 @@ func (c Pop3) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Pop3) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/rdp.go
+++ b/engine/checks/rdp.go
@@ -11,7 +11,7 @@ type Rdp struct {
 	Service
 }
 
-func (c Rdp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Rdp) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		_, err := net.DialTimeout("tcp", c.Target+":"+strconv.Itoa(c.Port), time.Duration(c.Timeout)*time.Second)
 		if err != nil {
@@ -24,7 +24,7 @@ func (c Rdp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Rdp) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/smb.go
+++ b/engine/checks/smb.go
@@ -23,7 +23,7 @@ type smbFile struct {
 	Regex string
 }
 
-func (c Smb) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Smb) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		var username, password string
 		if len(c.CredLists) == 0 {
@@ -148,7 +148,7 @@ func (c Smb) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		}
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Smb) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/smtp.go
+++ b/engine/checks/smtp.go
@@ -30,7 +30,7 @@ func (a unencryptedAuth) Start(server *smtp.ServerInfo) (string, []byte, error) 
 	return a.Auth.Start(&s)
 }
 
-func (c Smtp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Smtp) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		fortunes, err := os.ReadFile("/usr/share/fortune/fortunes")
 		if err != nil {
@@ -179,7 +179,7 @@ func (c Smtp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Smtp) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/sql.go
+++ b/engine/checks/sql.go
@@ -24,7 +24,7 @@ type queryData struct {
 	Output   string `toml:",omitempty"`
 }
 
-func (c Sql) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		username, password, err := c.getCreds(teamID)
 		if err != nil {
@@ -114,7 +114,7 @@ func (c Sql) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Sql) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/ssh.go
+++ b/engine/checks/ssh.go
@@ -29,7 +29,7 @@ type commandData struct {
 	Output   string `toml:",omitempty"`
 }
 
-func (c Ssh) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Ssh) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 
 		// Create client config
@@ -192,7 +192,7 @@ func (c Ssh) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Ssh) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/tcp.go
+++ b/engine/checks/tcp.go
@@ -11,7 +11,7 @@ type Tcp struct {
 	Service
 }
 
-func (c Tcp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Tcp) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		_, err := net.DialTimeout("tcp", c.Target+":"+strconv.Itoa(c.Port), time.Duration(c.Timeout)*time.Second)
 		if err != nil {
@@ -25,7 +25,7 @@ func (c Tcp) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Tcp) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/vnc.go
+++ b/engine/checks/vnc.go
@@ -12,7 +12,7 @@ type Vnc struct {
 	Service
 }
 
-func (c Vnc) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Vnc) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 
 		// Configure the vnc client
@@ -55,7 +55,7 @@ func (c Vnc) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Vnc) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/web.go
+++ b/engine/checks/web.go
@@ -28,7 +28,7 @@ type urlData struct {
 	CompareFile string `toml:",omitempty"` // TODO implement
 }
 
-func (c Web) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c Web) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		u := c.Url[rand.Intn(len(c.Url))]
 
@@ -104,7 +104,7 @@ func (c Web) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *Web) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/checks/winrm.go
+++ b/engine/checks/winrm.go
@@ -24,7 +24,7 @@ type winCommandData struct {
 	Output   string
 }
 
-func (c WinRM) Run(teamID uint, teamIdentifier string, resultsChan chan Result) {
+func (c WinRM) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan chan Result) {
 	definition := func(teamID uint, teamIdentifier string, checkResult Result, response chan Result) {
 		username, password, err := c.getCreds(teamID)
 		if err != nil {
@@ -97,7 +97,7 @@ func (c WinRM) Run(teamID uint, teamIdentifier string, resultsChan chan Result) 
 		response <- checkResult
 	}
 
-	c.Service.Run(teamID, teamIdentifier, resultsChan, definition)
+	c.Service.Run(teamID, teamIdentifier, roundID, resultsChan, definition)
 }
 
 func (c *WinRM) Verify(box string, ip string, points int, timeout int, slapenalty int, slathreshold int) error {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -277,6 +277,8 @@ func (se *ScoringEngine) rvb() {
 		val, err := se.RedisClient.BLPop(timeoutCtx, time.Until(se.NextRoundStartTime), "results").Result()
 		if err == redis.Nil {
 			slog.Warn("Timeout waiting for results", "remaining", runners-i)
+			// Clear the results, since we didn't collect everything in time
+			results = []checks.Result{}
 			break
 		} else if err != nil {
 			slog.Error("Failed to fetch results from Redis:", "error", err)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,7 +36,7 @@ type ScoringEngine struct {
 	SlaPerService         map[uint]map[string]int
 	EnginePauseWg         *sync.WaitGroup
 	IsEnginePaused        bool
-	CurrentRound          int
+	CurrentRound          uint
 	NextRoundStartTime    time.Time
 	CurrentRoundStartTime time.Time
 	RedisClient           *redis.Client
@@ -72,7 +72,7 @@ func (se *ScoringEngine) Start() {
 	if t, err := db.GetLastRound(); err != nil {
 		slog.Error("failed to get last round", "error", err)
 	} else {
-		se.CurrentRound = int(t.ID) + 1
+		se.CurrentRound = uint(t.ID) + 1
 	}
 
 	if err := db.LoadUptimes(&se.UptimePerService); err != nil {

--- a/www/middleware/logging.go
+++ b/www/middleware/logging.go
@@ -1,16 +1,52 @@
 package middleware
 
 import (
-	"fmt"
 	"log/slog"
 	"net/http"
 	"time"
+
+	"github.com/google/uuid"
 )
 
-func Logging(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+// Logging middleware logs quotient web requests. It is meant to be called after authentication is performed
+func Logging(next http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
+
+		// Generate (or reuse) a unique request ID.
+		requestID := r.Header.Get("X-Request-ID")
+		if requestID == "" {
+			requestID = uuid.New().String()
+		}
+		w.Header().Set("X-Request-ID", requestID)
+
+		// Process the request.
 		next.ServeHTTP(w, r)
-		slog.Info(fmt.Sprintf("%-7s %-20s %s", r.Method, r.URL.Path, time.Since(start)), "source", "web")
-	})
+		duration := time.Since(start)
+
+		// Determine the client IP.
+		clientIP := r.RemoteAddr
+		if forwarded := r.Header.Get("X-Forwarded-For"); forwarded != "" {
+			clientIP = forwarded
+		}
+
+		// Retrieve the username safely from the context.
+		username, ok := r.Context().Value("username").(string)
+		if !ok {
+			username = "anonymous"
+		}
+
+		// Log the request details.
+		slog.Info("HTTP request completed",
+			"request_id", requestID,
+			"client_ip", clientIP,
+			"user_id", username,
+			"method", r.Method,
+			"uri", r.RequestURI,
+			"protocol", r.Proto,
+			"duration", duration,
+			"referer", r.Referer(),
+			"user_agent", r.UserAgent(),
+		)
+	}
 }

--- a/www/router.go
+++ b/www/router.go
@@ -39,7 +39,7 @@ func (router *Router) Start() {
 
 	mux.Handle("/static/assets/", http.StripPrefix("/static/assets/", http.FileServer(http.Dir("./static/assets"))))
 
-	UNAUTH := middleware.MiddlewareChain(middleware.Authentication("anonymous", "team", "admin", "red"))
+	UNAUTH := middleware.MiddlewareChain(middleware.Logging, middleware.Authentication("anonymous", "team", "admin", "red"))
 	// public API routes
 	mux.HandleFunc("POST /api/login", api.Login)
 
@@ -59,7 +59,7 @@ func (router *Router) Start() {
 	|                                         |
 	******************************************/
 
-	ALLAUTH := middleware.MiddlewareChain(middleware.Authentication("team", "admin", "red"))
+	ALLAUTH := middleware.MiddlewareChain(middleware.Logging, middleware.Authentication("team", "admin", "red"))
 	// general auth API routes
 	mux.HandleFunc("GET /api/logout", ALLAUTH(api.Logout))
 
@@ -77,7 +77,7 @@ func (router *Router) Start() {
 	|                                         |
 	******************************************/
 
-	TEAMAUTH := middleware.MiddlewareChain(middleware.Authentication("team", "admin"))
+	TEAMAUTH := middleware.MiddlewareChain(middleware.Logging, middleware.Authentication("team", "admin"))
 	// team auth API routes
 	mux.HandleFunc("GET /api/teams", TEAMAUTH(api.GetTeams))
 	mux.HandleFunc("GET /api/services/{team_id}", TEAMAUTH(api.GetTeamSummary))
@@ -103,7 +103,7 @@ func (router *Router) Start() {
 	|                                         |
 	******************************************/
 
-	ADMINAUTH := middleware.MiddlewareChain(middleware.Authentication("admin"))
+	ADMINAUTH := middleware.MiddlewareChain(middleware.Logging, middleware.Authentication("admin"))
 	// admin auth API routes
 	mux.HandleFunc("POST /api/announcements/create", ADMINAUTH(api.CreateAnnouncement))
 	mux.HandleFunc("POST /api/announcements/{id}", ADMINAUTH(api.UpdateAnnouncement))
@@ -130,10 +130,11 @@ func (router *Router) Start() {
 	mux.HandleFunc("GET /admin/engine", ADMINAUTH(router.AdministrateEnginePage))
 	mux.HandleFunc("GET /admin/teams", ADMINAUTH(router.AdministrateTeamsPage))
 
+
 	// start server
 	server := http.Server{
 		Addr:    fmt.Sprintf("%s:%d", router.Config.RequiredSettings.BindAddress, router.Config.MiscSettings.Port),
-		Handler: middleware.Logging(mux),
+		Handler: mux,
 	}
 	slog.Info(fmt.Sprintf("Starting Web Server on %s://%s:%d", protocol, router.Config.RequiredSettings.BindAddress, router.Config.MiscSettings.Port))
 


### PR DESCRIPTION
Add round ID to correlate each service check with a round. This should mean that only results for the current round checks are collected. 

Also added round ID as a variable to be passed optionally to custom checks.