### PR TITLE
Fix log spam when Redis fails

### DIFF
--- a/custom-checks/requirements.txt
+++ b/custom-checks/requirements.txt
@@ -1,2 +1,2 @@
 #Enter your python modules here on newlines: e.g.
-#requests
+requests

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -253,6 +253,7 @@ func (se *ScoringEngine) rvb() {
 			break
 		} else if err != nil {
 			slog.Error("Failed to fetch results from Redis:", "error", err)
+			time.Sleep(2 * time.Second)
 			continue
 		}
 


### PR DESCRIPTION
Add a sleep after Redis failure so that logs aren't spammed when it loses connection.