### PR TITLE
Rewrote runner to be three functions primarily, getNextTask, createRunner, and handleTask

### DIFF
--- a/runner/runner.go
+++ b/runner/runner.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 	"time"
@@ -13,13 +14,7 @@ import (
 	"github.com/redis/go-redis/v9"
 )
 
-var (
-	input  = make(chan checks.Result)
-	output = make(chan []byte)
-)
-
 func main() {
-	// Redis connection info
 	redisAddr := os.Getenv("REDIS_ADDR")
 	if redisAddr == "" {
 		redisAddr = "quotient_redis:6379"
@@ -31,132 +26,163 @@ func main() {
 	})
 	ctx := context.Background()
 
-	log.Println("[Runner] Runner started, listening for tasks on Redis at:", "reddisAddr", redisAddr)
-
-	go jsonProcessor(input, output)
+	log.Printf("[Runner] Started, listening for tasks on Redis at: %s", redisAddr)
 
 	for {
-		// Block until we get a task from the "tasks" list (no timeout here).
-		val, err := rdb.BLPop(ctx, 0, "tasks").Result()
+		task, err := getNextTask(ctx, rdb)
 		if err != nil {
-			log.Println("[Runner] Failed to pop task from Redis: ", "err", err)
+			log.Printf("[Runner] Error getting task: %v", err)
 			continue
 		}
 
-		// val[0] = "tasks", val[1] = the JSON payload
-		if len(val) < 2 {
-			log.Println("[Runner] Invalid BLPop response:", val)
-			return
-		}
-		raw := val[1]
-
-		var task engine.Task
-		if err := json.Unmarshal([]byte(raw), &task); err != nil {
-			log.Println("[Runner] Invalid task format:", "err", err)
-			return
-		}
-		log.Printf("[Runner] Received task: RoundID: %d TeamID: %d TeamIdentifier: %s ServiceType: %s", task.RoundID, task.TeamID, task.TeamIdentifier, task.ServiceType)
-
-		var runnerInstance checks.Runner
-		switch task.ServiceType {
-		case "Custom":
-			runnerInstance = &checks.Custom{}
-		case "Dns":
-			runnerInstance = &checks.Dns{}
-		case "Ftp":
-			runnerInstance = &checks.Ftp{}
-		case "Imap":
-			runnerInstance = &checks.Imap{}
-		case "Ldap":
-			runnerInstance = &checks.Ldap{}
-		case "Ping":
-			runnerInstance = &checks.Ping{}
-		case "Pop3":
-			runnerInstance = &checks.Pop3{}
-		case "Rdp":
-			runnerInstance = &checks.Rdp{}
-		case "Smb":
-			runnerInstance = &checks.Smb{}
-		case "Smtp":
-			runnerInstance = &checks.Smtp{}
-		case "Sql":
-			runnerInstance = &checks.Sql{}
-		case "Ssh":
-			runnerInstance = &checks.Ssh{}
-		case "Tcp":
-			runnerInstance = &checks.Tcp{}
-		case "Vnc":
-			runnerInstance = &checks.Vnc{}
-		case "Web":
-			runnerInstance = &checks.Web{}
-		case "WinRM":
-			runnerInstance = &checks.WinRM{}
-		default:
-			log.Printf("[Runner] Unknown service type %s. Skipping.", task.ServiceType)
-			return
+		runner, err := createRunner(task)
+		if err != nil {
+			log.Printf("[Runner] Error creating runner: %v", err)
+			continue
 		}
 
-		// Deserialize the check data into that runner instance
-		if err := json.Unmarshal(task.CheckData, runnerInstance); err != nil {
-			log.Println("[Runner] Failed to unmarshal into", "task.ServiceType", task.ServiceType, "err", err)
-			return
-		}
-		log.Printf("[Runner] CheckData: %+v", runnerInstance)
-
-		// Create a channel to receive the check results
-		resultsChan := make(chan checks.Result)
-
-		// Run the check asynchronously to not block
-		go handleTask(ctx, rdb, runnerInstance, task, resultsChan)
+		go handleTask(ctx, rdb, runner, task)
 	}
 }
 
-func handleTask(ctx context.Context, rdb *redis.Client, runnerInstance checks.Runner, task engine.Task, resultsChan chan checks.Result) {
-	// this currently discards all failed attempts
-	var result checks.Result
-	for i := 0; i < task.Attempts; i++ {
-		// send the request
-		log.Printf("[Runner] Running check: RoundID=%d, TeamID=%d, ServiceType=%s, ServiceName=%s, Attempt=%d", task.RoundID, task.TeamID, task.ServiceType, task.ServiceName, i+1)
-		go runnerInstance.Run(task.TeamID, task.TeamIdentifier, task.RoundID, resultsChan)
+func getNextTask(ctx context.Context, rdb *redis.Client) (*engine.Task, error) {
+	// Block until we get a task from the "tasks" list
+	val, err := rdb.BLPop(ctx, 0, "tasks").Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to pop task: %w", err)
+	}
 
-		// wait for the response
+	// val[0] = "tasks", val[1] = the JSON payload
+	if len(val) < 2 {
+		return nil, fmt.Errorf("invalid BLPop response: %v", val)
+	}
+
+	var task engine.Task
+	if err := json.Unmarshal([]byte(val[1]), &task); err != nil {
+		return nil, fmt.Errorf("invalid task format: %w", err)
+	}
+
+	log.Printf("[Runner] Received task: RoundID=%d TeamID=%d TeamIdentifier=%s ServiceType=%s",
+		task.RoundID, task.TeamID, task.TeamIdentifier, task.ServiceType)
+
+	return &task, nil
+}
+
+func createRunner(task *engine.Task) (checks.Runner, error) {
+	var runner checks.Runner
+
+	switch task.ServiceType {
+	case "Custom":
+		runner = &checks.Custom{}
+	case "Dns":
+		runner = &checks.Dns{}
+	case "Ftp":
+		runner = &checks.Ftp{}
+	case "Imap":
+		runner = &checks.Imap{}
+	case "Ldap":
+		runner = &checks.Ldap{}
+	case "Ping":
+		runner = &checks.Ping{}
+	case "Pop3":
+		runner = &checks.Pop3{}
+	case "Rdp":
+		runner = &checks.Rdp{}
+	case "Smb":
+		runner = &checks.Smb{}
+	case "Smtp":
+		runner = &checks.Smtp{}
+	case "Sql":
+		runner = &checks.Sql{}
+	case "Ssh":
+		runner = &checks.Ssh{}
+	case "Tcp":
+		runner = &checks.Tcp{}
+	case "Vnc":
+		runner = &checks.Vnc{}
+	case "Web":
+		runner = &checks.Web{}
+	case "WinRM":
+		runner = &checks.WinRM{}
+	default:
+		return nil, fmt.Errorf("unknown service type: %s", task.ServiceType)
+	}
+
+	if err := json.Unmarshal(task.CheckData, runner); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal check data: %w", err)
+	}
+
+	log.Printf("[Runner] CheckData: %+v", runner)
+	return runner, nil
+}
+
+func handleTask(ctx context.Context, rdb *redis.Client, runner checks.Runner, task *engine.Task) {
+	// this currently discards all failed attempts
+	resultsChan := make(chan checks.Result, 1)
+	var result checks.Result
+
+	// Initialize default result fields
+	result = checks.Result{
+		TeamID:      task.TeamID,
+		ServiceName: task.ServiceName,
+		ServiceType: task.ServiceType,
+		RoundID:     task.RoundID,
+		Status:      false,
+	}
+
+	for i := range task.Attempts {
+		log.Printf("[Runner] Running check: RoundID=%d TeamID=%d ServiceType=%s ServiceName=%s Attempt=%d",
+			task.RoundID, task.TeamID, task.ServiceType, task.ServiceName, i+1)
+
+		// Create context with deadline
+		checkCtx, cancel := context.WithDeadline(ctx, task.Deadline)
+		defer cancel()
+
+		// Run the check in a goroutine
+		go runner.Run(task.TeamID, task.TeamIdentifier, task.RoundID, resultsChan)
+
+		// Wait for either result or deadline
 		select {
 		case result = <-resultsChan:
-		case <-time.After(time.Until(task.Deadline)):
-			log.Printf("[Runner] Timeout occured: RoundID=%d, TeamID=%d, ServiceType=%s, ServiceName=%s", task.RoundID, task.TeamID, task.ServiceType, task.ServiceName)
-			result = checks.Result{
-				TeamID:      task.TeamID,
-				ServiceName: task.ServiceName,
-				ServiceType: task.ServiceType,
-				RoundID:     task.RoundID,
-				Status:      false,
-				Debug:       "round ended before check completed",
-				Error:       "timeout",
-			}
+			result.TeamID = task.TeamID
+			result.ServiceName = task.ServiceName
+			result.ServiceType = task.ServiceType
+			result.RoundID = task.RoundID
+
+			log.Printf("[Runner] Check result received: RoundID=%d TeamID=%d ServiceType=%s Status=%v Debug=%s Error=%s",
+				result.RoundID, result.TeamID, result.ServiceType, result.Status, result.Debug, result.Error)
+
+		case <-checkCtx.Done():
+			result.Status = false
+			result.Debug = "round ended before check completed"
+			result.Error = "timeout"
+			result.TeamID = task.TeamID
+			result.ServiceName = task.ServiceName
+			result.ServiceType = task.ServiceType
+			result.RoundID = task.RoundID
+
+			log.Printf("[Runner] Check timed out: RoundID=%d TeamID=%d ServiceType=%s",
+				task.RoundID, task.TeamID, task.ServiceType)
 		}
 
-		// if fail, retry, else stop retrying
-		if time.Now().Before(task.Deadline) && !result.Status {
-			continue
+		// Break if successful or deadline passed
+		if result.Status || time.Now().After(task.Deadline) {
+			break
 		}
-		break
 	}
-	// Marshall the check result
-	input <- result
-	resultJSON := <-output
 
-	// Push onto "results" list
+	// Marshal and store result
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		log.Printf("[Runner] Failed to marshal result: %v", err)
+		return
+	}
+
 	if err := rdb.RPush(ctx, "results", resultJSON).Err(); err != nil {
 		log.Printf("[Runner] Failed to push result to Redis: %v", err)
-	} else {
-		log.Printf("[Runner] Pushed result for: RoundID=%d, TeamID=%d, ServiceType=%s, ServiceName=%s", task.RoundID, task.TeamID, task.ServiceType, task.ServiceName)
+		return
 	}
-}
 
-// serialize json to minimize in use memory
-func jsonProcessor(input chan checks.Result, output chan []byte) {
-	for result := range input {
-		resultJSON, _ := json.Marshal(result)
-		output <- resultJSON
-	}
+	log.Printf("[Runner] Successfully pushed result: RoundID=%d TeamID=%d ServiceType=%s Status=%v",
+		result.RoundID, result.TeamID, result.ServiceType, result.Status)
 }


### PR DESCRIPTION
This fixes a problem where runner was returning a blank result which only included `round_id: 0`. I think this makes it clearer what the runner is doing and retains the functionality to retry failed checks.