### PR TITLE
Several bug fixes and LDAP .env support

### DIFF
--- a/engine/checks/sql.go
+++ b/engine/checks/sql.go
@@ -90,11 +90,12 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 						checkResult.Status = true
 						checkResult.Debug = "found regex match: " + output + ". creds used were " + username + ":" + password
 						response <- checkResult
+						break
 					}
 				} else {
 					if strings.TrimSpace(output) == q.Output {
 						checkResult.Status = true
-						checkResult.Debug = "found exact string match: " + output + ".creds used were " + username + ":" + password
+						checkResult.Debug = "found exact string match: " + output + ". creds used were " + username + ":" + password
 						response <- checkResult
 						break
 					}
@@ -107,6 +108,7 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 				response <- checkResult
 				return
 			}
+			return
 		}
 
 		checkResult.Debug = "desired output " + output + "not found in any output. creds used were " + username + ":" + password

--- a/engine/checks/sql.go
+++ b/engine/checks/sql.go
@@ -34,9 +34,14 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 			return
 		}
 
-		// Run query
-		q := c.Query[rand.Intn(len(c.Query))]
+		// Select a random query
+		// If no queries defined, just use empty query
+		var q queryData
+		if len(c.Query) != 0 {
+			q = c.Query[rand.Intn(len(c.Query))]
+		}
 
+		// Open the DB handle
 		db, err := sql.Open(c.Kind, fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", username, password, c.Target, c.Port, q.Database))
 		if err != nil {
 			checkResult.Error = "creating db handle failed"
@@ -46,7 +51,7 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 		}
 		defer db.Close()
 
-		// Check db connection
+		// Check DB connection
 		err = db.PingContext(context.TODO())
 		if err != nil {
 			checkResult.Error = "db connection or login failed"
@@ -55,64 +60,91 @@ func (c Sql) Run(teamID uint, teamIdentifier string, roundID uint, resultsChan c
 			return
 		}
 
-		// Query the DB
-		var rows *sql.Rows
-		if q.Command == "" {
-			checkResult.Debug = "no query command, only checking connection. creds used were " + username + ":" + password
+		// If no query command to run, return success
+		if len(c.Query) == 0 || q.Command == "" {
+			checkResult.Debug = "no query command specified, only checking connection. creds used were " + username + ":" + password
 			checkResult.Status = true
 			response <- checkResult
+			return
 		}
 
+		// Query the DB
+		var rows *sql.Rows
 		rows, err = db.QueryContext(context.TODO(), q.Command)
 		if err != nil {
-			checkResult.Error = "could not query db for database " + q.Command
+			checkResult.Error = "could not query db with command " + q.Command
 			checkResult.Debug = err.Error()
 			response <- checkResult
 			return
 		}
 		defer rows.Close()
 
-		var output string
-		if q.Output != "" {
-			// Check the rows
-			for rows.Next() {
-				// Grab a value
-				err := rows.Scan(&output)
-				if err != nil {
-					checkResult.Error = "could not get row values"
-					checkResult.Debug = err.Error()
-					response <- checkResult
-					return
-				}
-				if q.UseRegex {
-					re := regexp.MustCompile(q.Output)
-					if re.Match([]byte(output)) {
-						checkResult.Status = true
-						checkResult.Debug = "found regex match: " + output + ". creds used were " + username + ":" + password
-						response <- checkResult
-						break
-					}
-				} else {
-					if strings.TrimSpace(output) == q.Output {
-						checkResult.Status = true
-						checkResult.Debug = "found exact string match: " + output + ". creds used were " + username + ":" + password
-						response <- checkResult
-						break
-					}
-				}
-			}
-			// Check for error in the rows
-			if rows.Err() != nil {
-				checkResult.Error = "sql rows experienced an error"
-				checkResult.Debug = rows.Err().Error()
-				response <- checkResult
-				return
-			}
+		// If no output to check, return success
+		if q.Output == "" {
+			checkResult.Debug = "ran query sucessfully and no output to check against. creds used were " + username + ":" + password
+			checkResult.Status = true
+			response <- checkResult
 			return
 		}
 
-		checkResult.Debug = "desired output " + output + "not found in any output. creds used were " + username + ":" + password
-		checkResult.Error = "output incorrect"
+		// Check the rows
+		re := regexp.MustCompile(q.Output)
+		cols, err := rows.Columns()
+		if err != nil {
+			// handle error
+			checkResult.Error = "could not get sql columns"
+			checkResult.Debug = err.Error()
+			response <- checkResult
+			return
+		}
+
+		// Make a slice for the values
+		row := make([][]byte, len(cols))
+		rowPtr := make([]any, len(cols))
+		for i := range row {
+			rowPtr[i] = &row[i]
+		}
+
+		for rows.Next() {
+			// Grab a value
+			err := rows.Scan(rowPtr...)
+			if err != nil {
+				checkResult.Error = "could not get row values"
+				checkResult.Debug = err.Error()
+				response <- checkResult
+				return
+			}
+
+			// TODO: by default we check against the first column
+			// Check the regex match
+			if q.UseRegex {
+				if re.Match(row[0]) {
+					checkResult.Status = true
+					checkResult.Debug = "found regex match: " + string(row[0]) + ". creds used were " + username + ":" + password
+					response <- checkResult
+					return
+				}
+				// Check the direct string match
+			} else {
+				if strings.TrimSpace(string(row[0])) == q.Output {
+					checkResult.Status = true
+					checkResult.Debug = "found exact string match: " + string(row[0]) + ". creds used were " + username + ":" + password
+					response <- checkResult
+					return
+				}
+			}
+		}
+
+		// Check for error in the rows
+		if rows.Err() != nil {
+			checkResult.Error = "sql rows experienced an error"
+			checkResult.Debug = rows.Err().Error()
+			response <- checkResult
+			return
+		}
+
+		// No matches found
+		checkResult.Debug = "no matching output found for query. creds used were " + username + ":" + password
 		response <- checkResult
 	}
 
@@ -143,6 +175,5 @@ func (c *Sql) Verify(box string, ip string, points int, timeout int, slapenalty 
 			regexp.MustCompile(q.Output)
 		}
 	}
-
 	return nil
 }

--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -202,6 +202,17 @@ func checkConfig(conf *ConfigSettings) error {
 		errResult = errors.Join(errResult, errors.New("no bind address specified"))
 	}
 
+	if conf.LdapSettings != (LdapAuthConfig{}) {
+		if conf.LdapSettings.LdapBindPassword == "" {
+			ldapBindPass := os.Getenv("LDAP_BIND_PASSWORD")
+			if ldapBindPass != "" {
+				conf.LdapSettings.LdapBindPassword = ldapBindPass
+			} else {
+				errResult = errors.Join(errResult, errors.New("no LDAP bind password specified"))
+			}
+		}
+	}
+
 	// check top level configs
 	for _, admin := range conf.Admin {
 		if admin.Name == "" || admin.Pw == "" {

--- a/static/templates/pages/graphs.html
+++ b/static/templates/pages/graphs.html
@@ -146,7 +146,8 @@
                                         const teamID = TEAMMAP[series[i].name]
                                         const serviceName = status.x
                                         const pointID = `status-${teamID}-${j}`
-
+                                        const rowHeight = STATUSCHART.w.globals.gridHeight / series.length;
+                                        
                                         let point = {
                                             x: serviceName,
                                             y: STATUSCHART.w.globals.yRange[0],
@@ -154,7 +155,7 @@
                                             id: pointID,
                                             image: {
                                                 path: img,
-                                                offsetY: (5+(series.length-1)*17)-i*17,
+                                                offsetY: (rowHeight * series.length) + (rowHeight / 2) - (i * rowHeight) - rowHeight,
                                             },
                                             click: () => {
                                                 if (teamID !== undefined) {

--- a/static/templates/pages/injects.html
+++ b/static/templates/pages/injects.html
@@ -510,8 +510,8 @@
                 <p>${inject.Description}</p>
                 <h5>Inject Details</h5>
                 <ul>
-                    <li id="pane__due--${inject.ID}"><p><strong>Due Time:</strong> ${inject.DueTime.toLocaleString()}</p></li>
-                    <li id="pane__close--${inject.ID}"><p><strong>Close Time:</strong> ${inject.CloseTime.toLocaleString()}</p></li>
+                    <li><p><strong>Due Time:</strong> <span id="pane__due--${inject.ID}">${inject.DueTime.toLocaleString()}</span></p></li>
+                    <li><p><strong>Close Time:</strong> <span id="pane__close--${inject.ID}">${inject.CloseTime.toLocaleString()}</span></p></li>
                     </ul>
                     `
                     description.appendChild(descTemp)


### PR DESCRIPTION
- Added support for specifying the LDAP bind password in the .env file using `LDAP_BIND_PASSWORD`
- Rewrote the SQL check because it was pretty broken
  - Successful checks would never close the database connection due to trying to send two messages to the results channel, which eventually hits MySQL's max connection limit and breaks scoring
  - Other edge cases were also broken
- Added a unicode sanitizer for checks being inserted to the database (probably could be improved)
  - Windows sometimes puts null bytes in its errors, which causes a unicode error when trying to insert said string into the database, breaking scoring
- Fixed spacing for up/down icons on the graphs page so it scales properly with number of teams
- Fixed a bug with the edit feature for injects