### PR TITLE
Sanitize LDAP query inputs

### DIFF
--- a/www/api/authentication.go
+++ b/www/api/authentication.go
@@ -201,7 +201,7 @@ func auth(username string, password string) (map[string]any, error) {
 		searchRequest := ldap.NewSearchRequest(
 			conf.LdapSettings.LdapSearchBaseDn,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", username),
+			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", ldap.EscapeFilter(username)),
 			[]string{"dn"},
 			nil,
 		)
@@ -226,7 +226,7 @@ func auth(username string, password string) (map[string]any, error) {
 		roleSearchRequest := ldap.NewSearchRequest(
 			conf.LdapSettings.LdapSearchBaseDn,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", username),
+			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", ldap.EscapeFilter(username)),
 			[]string{"memberOf"},
 			nil,
 		)
@@ -295,7 +295,7 @@ func findRolesByUsername(username string) ([]string, error) {
 		searchRequest := ldap.NewSearchRequest(
 			conf.LdapSettings.LdapSearchBaseDn,
 			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
-			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", username),
+			fmt.Sprintf("(&(objectClass=person)(sAMAccountName=%s))", ldap.EscapeFilter(username)),
 			[]string{"memberOf"},
 			nil,
 		)


### PR DESCRIPTION
Applies proper escaping to LDAP filter queries to prevent filter injection attacks.