### PR TITLE
Revert struct reorder in ExportScores

### DIFF
--- a/www/api/admin.go
+++ b/www/api/admin.go
@@ -44,18 +44,18 @@ func ResetScores(w http.ResponseWriter, r *http.Request) {
 }
 
 func ExportScores(w http.ResponseWriter, r *http.Request) {
-	type TeamScore struct {
-		TeamID      uint           `json:"team_id"`
-		TeamName    string         `json:"team_name"`
-		Services    []ServiceScore `json:"services"`
-		TotalPoints int            `json:"total_points"`
-	}
-
 	type ServiceScore struct {
 		ServiceName   string `json:"service_name"`
 		Points        int    `json:"service_points"`
 		SlaViolations int    `json:"sla_violations"`
 		SlaPenalty    int    `json:"sla_penalty"`
+	}
+
+	type TeamScore struct {
+		TeamID      uint           `json:"team_id"`
+		TeamName    string         `json:"team_name"`
+		Services    []ServiceScore `json:"services"`
+		TotalPoints int            `json:"total_points"`
 	}
 
 	teams, err := db.GetTeams()


### PR DESCRIPTION
Reverts the struct reorder from commit 44e67e5b32d31717e1043c765b282bd4943415de.

This restores `ServiceScore` to be defined before `TeamScore` in the `ExportScores` function, which is the logical order since `TeamScore` references `ServiceScore`.