### PR TITLE
Clear annotations before adding new ones in graphs

### DIFF
--- a/static/templates/pages/graphs.html
+++ b/static/templates/pages/graphs.html
@@ -131,6 +131,7 @@
                                 })
                                 // y value is based on y value for some reason, so manually setting y value to
                                 // consistent value for all series to make sure the images are at a consistent height
+                                STATUSCHART.clearAnnotations()
                                 for (let i = 0; i < series.length; i++) {
                                     for (let j = 0; j < series[i].data.length; j++) {
                                         let status = series[i].data[j]


### PR DESCRIPTION
I think this is needed to clear annotations before assigning them. Otherwise they just sit in memory forever.