### PR TITLE
Add tini to Dockerfile.runner dependencies

### DIFF
--- a/Dockerfile.runner
+++ b/Dockerfile.runner
@@ -13,7 +13,7 @@ RUN go build -o runner
 FROM alpine:3.21
 WORKDIR /app
 COPY --from=builder /src/runner/runner runner
-RUN apk add --no-cache wireguard-tools iproute2 iputils curl git openssh py3-uv python3 proxychains-ng jq file sshpass bind-tools grep chrony krb5
+RUN apk add --no-cache tini wireguard-tools iproute2 iputils curl git openssh py3-uv python3 proxychains-ng jq file sshpass bind-tools grep chrony krb5
 
 # custom python check scripts
 COPY custom-checks/requirements.txt /app


### PR DESCRIPTION
Fixes #126. This was originally inside the Dockerfile, but i have no idea where it went. It's even in the git history, but not the blame. 