### PR TITLE
Fix concurrent map crash in UptimePerService

### DIFF
--- a/www/api/graphs.go
+++ b/www/api/graphs.go
@@ -165,6 +165,7 @@ func GetUptimeStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	teams = slices.DeleteFunc(teams, func(team db.TeamSchema) bool { return !team.Active })
 
+	eng.RLockUptime()
 	uptime := eng.GetUptimePerService()
 
 	// TODO: make db unique function or get from config
@@ -205,6 +206,7 @@ func GetUptimeStatus(w http.ResponseWriter, r *http.Request) {
 		s.Data = points
 		series = append(series, s)
 	}
+	eng.RUnlockUptime()
 
 	if shouldScrub(r) {
 		for i := range series {

--- a/www/api/services.go
+++ b/www/api/services.go
@@ -154,9 +154,11 @@ func GetTeamSummary(w http.ResponseWriter, r *http.Request) {
 		Uptime       float64          `json:"Uptime"`
 	}
 
+	eng.RLockUptime()
+	uptimeMap := eng.GetUptimePerService()
 	var s []summary
 	for _, v := range summaries {
-		uptime := eng.UptimePerService[teamID][v["ServiceName"].(string)]
+		uptime := uptimeMap[teamID][v["ServiceName"].(string)]
 		s = append(s, summary{
 			ServiceName:  v["ServiceName"].(string),
 			SlaCount:     v["SlaCount"].(int),
@@ -164,6 +166,7 @@ func GetTeamSummary(w http.ResponseWriter, r *http.Request) {
 			Uptime:       float64(uptime.PassedChecks) / float64(uptime.TotalChecks),
 		})
 	}
+	eng.RUnlockUptime()
 
 	WriteJSON(w, http.StatusOK, s)
 }


### PR DESCRIPTION
  fatal error: concurrent map iteration and map write

  goroutine 366332 [running]:
  internal/runtime/maps.fatal({0x108cc23?, 0x47bc2f?})
        /usr/local/go/src/runtime/panic.go:1046 +0x18
  internal/runtime/maps.(*Iter).Next(0xc000b09640?)
        /usr/local/go/src/internal/runtime/maps/table.go:792 +0x86
  quotient/www/api.GetUptimeStatus({0x121bb10, 0xc0004fc5a0}, 0xc000210b40)
        /src/www/api/graphs.go:198 +0x91b
  net/http.HandlerFunc.ServeHTTP(...)
        /usr/local/go/src/net/http/server.go:2322
  quotient/www/middleware.Logging.func1({0x121bb10, 0xc0004fc5a0}, 0xc000210b40)
        /src/www/middleware/logging.go:25 +0x2b8
  net/http.HandlerFunc.ServeHTTP(...)
        /usr/local/go/src/net/http/server.go:2322
  quotient/www/middleware.Cors.func1({0x121bb10, 0xc0004fc5a0}, 0xc000210b40)
        /src/www/middleware/cors.go:18 +0x272
  quotient/www.(*Router).Start.Authentication.func2.1({0x121bb10, 0xc0004fc5a0}, 0xc000210a00)
        /src/www/middleware/authentication.go:41 +0x31e
  net/http.HandlerFunc.ServeHTTP(0xc00045aa80?, {0x121bb10?, 0xc0004fc5a0?}, 0xec4500?)
        /usr/local/go/src/net/http/server.go:2322 +0x29
  net/http.(*ServeMux).ServeHTTP(0x12?, {0x121bb10, 0xc0004fc5a0}, 0xc000210a00)
        /usr/local/go/src/net/http/server.go:2861 +0x1c7

  The engine goroutine was writing to se.UptimePerService in processCollectedResults while an HTTP handler was iterating the same map in GetUptimeStatus at graphs.go:198. Go's runtime detected this and killed the process.