### PR TITLE
Fix incorrect module path

### DIFF
--- a/engine/config/config.go
+++ b/engine/config/config.go
@@ -6,10 +6,11 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"quotient/engine/checks"
 	"slices"
 	"sort"
 	"strings"
+
+	"github.com/dbaseqp/Quotient/engine/checks"
 
 	"github.com/BurntSushi/toml"
 )

--- a/engine/credentials.go
+++ b/engine/credentials.go
@@ -7,8 +7,9 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"quotient/engine/db"
 	"sync"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 // safeOpenInDir opens a file within the given base directory safely using os.Root.

--- a/engine/db/db.go
+++ b/engine/db/db.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"os"
 
-	"quotient/engine/config"
+	"github.com/dbaseqp/Quotient/engine/config"
 
 	"github.com/go-ldap/ldap/v3"
 	"gorm.io/driver/postgres"

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -13,9 +13,9 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"quotient/engine/checks"
-	"quotient/engine/config"
-	"quotient/engine/db"
+	"github.com/dbaseqp/Quotient/engine/checks"
+	"github.com/dbaseqp/Quotient/engine/config"
+	"github.com/dbaseqp/Quotient/engine/db"
 
 	"github.com/redis/go-redis/v9"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module quotient
+module github.com/dbaseqp/Quotient
 
 go 1.25.1
 

--- a/go.sum
+++ b/go.sum
@@ -188,6 +188,7 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.17.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/main.go
+++ b/main.go
@@ -6,10 +6,10 @@ import (
 	"log/slog"
 	"os"
 
-	"quotient/engine"
-	"quotient/engine/config"
-	"quotient/engine/db"
-	"quotient/www"
+	"github.com/dbaseqp/Quotient/engine"
+	"github.com/dbaseqp/Quotient/engine/config"
+	"github.com/dbaseqp/Quotient/engine/db"
+	"github.com/dbaseqp/Quotient/www"
 )
 
 var logLvels = map[string]slog.Level{

--- a/www/api/admin.go
+++ b/www/api/admin.go
@@ -4,8 +4,9 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"quotient/engine/db"
 	"regexp"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 var validIdentifierRegex = regexp.MustCompile(`^[0-9]{1,3}$`)

--- a/www/api/announcements.go
+++ b/www/api/announcements.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"quotient/engine/db"
 	"slices"
 	"time"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 
 	"gorm.io/gorm"
 )

--- a/www/api/api.go
+++ b/www/api/api.go
@@ -6,9 +6,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"quotient/engine"
-	"quotient/engine/config"
-	"quotient/engine/db"
+
+	"github.com/dbaseqp/Quotient/engine"
+	"github.com/dbaseqp/Quotient/engine/config"
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 var (

--- a/www/api/authentication.go
+++ b/www/api/authentication.go
@@ -10,9 +10,10 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"quotient/engine/config"
 	"strings"
 	"time"
+
+	"github.com/dbaseqp/Quotient/engine/config"
 
 	"github.com/go-ldap/ldap/v3"
 	"github.com/gorilla/securecookie"

--- a/www/api/graphs.go
+++ b/www/api/graphs.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"net/http"
-	"quotient/engine/db"
 	"slices"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 const (

--- a/www/api/injects.go
+++ b/www/api/injects.go
@@ -7,9 +7,10 @@ import (
 	"net/http"
 	"os"
 	"path"
-	"quotient/engine/db"
 	"slices"
 	"time"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 
 	"gorm.io/gorm"
 )

--- a/www/api/metadata.go
+++ b/www/api/metadata.go
@@ -2,7 +2,8 @@ package api
 
 import (
 	"net/http"
-	"quotient/engine/checks"
+
+	"github.com/dbaseqp/Quotient/engine/checks"
 )
 
 type BoxMetadata struct {

--- a/www/api/pcrs.go
+++ b/www/api/pcrs.go
@@ -5,9 +5,10 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"quotient/engine/db"
 	"slices"
 	"strconv"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 func GetCredlists(w http.ResponseWriter, r *http.Request) {

--- a/www/api/red.go
+++ b/www/api/red.go
@@ -6,8 +6,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"quotient/engine/db"
 	"strconv"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 func GetRed(w http.ResponseWriter, r *http.Request) {

--- a/www/api/services.go
+++ b/www/api/services.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"quotient/engine/db"
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 func GetTeams(w http.ResponseWriter, r *http.Request) {

--- a/www/api/submissions.go
+++ b/www/api/submissions.go
@@ -9,10 +9,11 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"quotient/engine/db"
 	"slices"
 	"strconv"
 	"time"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 func CreateSubmission(w http.ResponseWriter, r *http.Request) {

--- a/www/api/teamchecks.go
+++ b/www/api/teamchecks.go
@@ -4,7 +4,8 @@ import (
 	"encoding/json"
 	"log/slog"
 	"net/http"
-	"quotient/engine/db"
+
+	"github.com/dbaseqp/Quotient/engine/db"
 )
 
 // GetTeamChecks returns per-team service check states for admins

--- a/www/frontend.go
+++ b/www/frontend.go
@@ -3,10 +3,11 @@ package www
 import (
 	"maps"
 	"net/http"
-	"quotient/engine/db"
-	"quotient/www/api"
 	"slices"
 	"text/template"
+
+	"github.com/dbaseqp/Quotient/engine/db"
+	"github.com/dbaseqp/Quotient/www/api"
 )
 
 var (

--- a/www/middleware/authentication.go
+++ b/www/middleware/authentication.go
@@ -3,9 +3,10 @@ package middleware
 import (
 	"context"
 	"net/http"
-	"quotient/www/api"
 	"slices"
 	"strings"
+
+	"github.com/dbaseqp/Quotient/www/api"
 )
 
 // load in authentication sources

--- a/www/middleware/securityheaders.go
+++ b/www/middleware/securityheaders.go
@@ -2,7 +2,8 @@ package middleware
 
 import (
 	"net/http"
-	"quotient/engine/config"
+
+	"github.com/dbaseqp/Quotient/engine/config"
 )
 
 // SecurityHeaders adds essential security headers to all responses

--- a/www/router.go
+++ b/www/router.go
@@ -7,10 +7,10 @@ import (
 	"net/http"
 	"time"
 
-	"quotient/engine"
-	"quotient/engine/config"
-	"quotient/www/api"
-	"quotient/www/middleware"
+	"github.com/dbaseqp/Quotient/engine"
+	"github.com/dbaseqp/Quotient/engine/config"
+	"github.com/dbaseqp/Quotient/www/api"
+	"github.com/dbaseqp/Quotient/www/middleware"
 )
 
 type Router struct {


### PR DESCRIPTION
Fixes incorrect Go module path, according to the [Go module reference](https://go.dev/doc/modules/gomod-ref#module), the path should be where the module can be downloaded from, otherwise the module cannot be downloaded by Go tools. Since the repo is at `github.com/dbaseqp/Quotient` that should be the module name, instead of simply `quotient` (which implies it's part of the standard library since there is no prefix).